### PR TITLE
fix "npm run build" error - install missing packages: gitter, larder and etc. lock package version. add laravel-elixir-browserify-official

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /public
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /public
 .DS_Store
+*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 script: bash ./scripts.sh deploy
 language: node_js
 node_js:
-- '5'
+- '6'
 env:
   global:
   - GH_REF: github.com/websemantics/strong-together.git

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 process.env.DISABLE_NOTIFIER = true
 
 var elixir = require('laravel-elixir')
+             require('laravel-elixir-browserify-official')
              require('laravel-elixir-vueify');
 
     elixir.config.sourcemaps = false;

--- a/package.json
+++ b/package.json
@@ -15,17 +15,21 @@
     "watch": "nodemon -q -w './resources/' --ext '.' --exec 'npm run build' "
   },
   "dependencies": {
-    "vue": "^1.0.0"
+    "bragit": "^1.0.6",
+    "vue": "^1.0.0",
+    "vue-resource": "^0.7.0",
+    "vue-router": "^0.7.13",
+    "base-64": "^0.1.0",
+    "gitters": "^1.0.6",
+    "larder": "^1.0.2"
   },
   "devDependencies": {
-    "vue-router": "*",
-    "vue-resource": "^0.7.0",
     "gulp": "^3.8.8",
-    "semantic-ui-less": "*",
     "jquery": "^2.1.4",
-    "laravel-elixir": "^5.0.0",
-    "laravel-elixir-vueify": "*",
-    "bragit": "*",
-    "nodemon": "*"
+    "laravel-elixir": "^6.0.0-15",
+    "laravel-elixir-browserify-official": "^0.1.3",
+    "laravel-elixir-vueify": "^2.0.0",
+    "nodemon": "^1.11.0",
+    "semantic-ui-less": "^2.2.12"
   }
 }


### PR DESCRIPTION
This pull request addresses the github issue #2 

previous:
```bash
.../laravel-elixir-vueify/index.js:3
Elixir.ready(() => {
       ^

TypeError: Elixir.ready is not a function

    at Object.<anonymous> (.../laravel-elixir-vueify/index.js:3:8)
    at Module._compile (module.js:573:32)
    at Object.Module._extensions..js (module.js:582:10)
    at Module.load (module.js:490:32)
    at tryModuleLoad (module.js:449:12)
    at Function.Module._load (module.js:441:3)
    at Module.require (module.js:500:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (.../gulpfile.js:4:14)
    at Module._compile (module.js:573:32)
```

current (with the change in this PR):
```bash
| => gulp
[23:11:07] Using gulpfile ~/Documents/node/strong-together-tmp/gulpfile.js
[23:11:07] Starting 'all'...
[23:11:07] Starting 'scripts'...
[23:11:07] Finished 'scripts' after 86 ms
[23:11:07] Starting 'less'...
[23:11:13] Finished 'less' after 6.4 s
[23:11:13] Starting 'browserify'...
[23:11:17] Finished 'browserify' after 3.69 s
[23:11:17] Starting 'copy'...
[23:11:17] Finished 'copy' after 8.48 ms
[23:11:17] Starting 'copy'...
[23:11:17] Finished 'copy' after 25 ms
[23:11:17] Starting 'copy'...
[23:11:17] Finished 'copy' after 119 ms
[23:11:17] Starting 'copy'...
[23:11:17] Finished 'copy' after 16 ms
[23:11:17] Starting 'styles'...
[23:11:17] Finished 'styles' after 9.07 ms
[23:11:17] Finished 'all' after 10 s
[23:11:17] Starting 'default'...
┌──────────────────┬──────────────────────────┬───────────────────────────────────────────────────────────────────┬────────────────────────┐
│ Task             │ Summary                  │ Source Files                                                      │ Destination            │
├──────────────────┼──────────────────────────┼───────────────────────────────────────────────────────────────────┼────────────────────────┤
│ mix.scripts()    │ 1. Concatenating Files   │ node_modules/jquery/dist/jquery.js                                │ public/js/all.js       │
│                  │ 2. Saving to Destination │ node_modules/semantic-ui-less/definitions/behaviors/visibility.js │                        │
│                  │                          │ node_modules/semantic-ui-less/definitions/modules/sidebar.js      │                        │
│                  │                          │ node_modules/semantic-ui-less/definitions/modules/transition.js   │                        │
├──────────────────┼──────────────────────────┼───────────────────────────────────────────────────────────────────┼────────────────────────┤
│ mix.less()       │ 1. Compiling Less        │ resources/assets/less/app.less                                    │ public/css/app.css     │
│                  │ 2. Autoprefixing CSS     │                                                                   │                        │
│                  │ 3. Concatenating Files   │                                                                   │                        │
│                  │ 4. Saving to Destination │                                                                   │                        │
├──────────────────┼──────────────────────────┼───────────────────────────────────────────────────────────────────┼────────────────────────┤
│ mix.browserify() │                          │ resources/assets/js/app.js                                        │ public/js/app.js       │
├──────────────────┼──────────────────────────┼───────────────────────────────────────────────────────────────────┼────────────────────────┤
│ mix.copy()       │ 1. Saving to Destination │ resources/assets/views/index.html                                 │ public/index.html      │
├──────────────────┼──────────────────────────┼───────────────────────────────────────────────────────────────────┼────────────────────────┤
│ mix.copy()       │ 1. Saving to Destination │ resources/assets/img/**/*                                         │ public/img             │
├──────────────────┼──────────────────────────┼───────────────────────────────────────────────────────────────────┼────────────────────────┤
│ mix.copy()       │ 1. Saving to Destination │ resources/assets/fonts/**/*                                       │ public/fonts/roboto    │
├──────────────────┼──────────────────────────┼───────────────────────────────────────────────────────────────────┼────────────────────────┤
│ mix.copy()       │ 1. Saving to Destination │ node_modules/semantic-ui-less/themes/default/assets/fonts/**/*    │ public/fonts/semantic  │
├──────────────────┼──────────────────────────┼───────────────────────────────────────────────────────────────────┼────────────────────────┤
│ mix.styles()     │ 1. Concatenating Files   │ resources/assets/css/**/*.css                                     │ public/css/vendors.css │
│                  │ 2. Saving to Destination │                                                                   │                        │
└──────────────────┴──────────────────────────┴───────────────────────────────────────────────────────────────────┴────────────────────────┘
[23:11:17] Finished 'default' after 14 ms
```